### PR TITLE
remove console.log

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,6 @@ Sentry.prototype.log = function (level, message, meta, callback) {
             message = meta.error;
             delete meta.error;
         }
-        console.log(message, extra);
         this._sentry.captureError(message, extra, function() {
             callback(null, true);
         });


### PR DESCRIPTION
because it does the job that console transport will do
